### PR TITLE
Simplify chain reorg detection code

### DIFF
--- a/raiden_libs/blockchain.py
+++ b/raiden_libs/blockchain.py
@@ -225,7 +225,7 @@ class BlockchainListener(gevent.Greenlet):
         if not self.wait_sync_event.is_set() and new_unconfirmed_head_number == current_block:
             self.wait_sync_event.set()
 
-    def filter_events(self, filter_params: dict, name_to_callback: dict) -> None:
+    def filter_events(self, filter_params: Dict, name_to_callback: Dict):
         """Params:
             filter_params: arguments for the filter call
             name_to_callback: dict that maps event name to callbacks executed
@@ -242,41 +242,43 @@ class BlockchainListener(gevent.Greenlet):
                 log.debug('Received confirmed %s event', event_name)
                 callback(event)
 
-    def reset_unconfirmed_on_reorg(self, current_block):
+    def _detected_chain_reorg(self, current_block: int):
+        log.info(
+            'Chain reorganization detected. '
+            'Resyncing unconfirmed events (unconfirmed_head=%d) [@%d]' %
+            (self.unconfirmed_head_number, current_block)
+        )
+        # here we should probably have a callback or a user-overriden method
+        self.unconfirmed_head_number = self.confirmed_head_number
+        self.unconfirmed_head_hash = self.confirmed_head_hash
+
+    def reset_unconfirmed_on_reorg(self, current_block: int):
         """Test if chain reorganization happened (head number used in previous pass is greater than
         current_block parameter) and in that case reset unconfirmed event list."""
         if self.wait_sync_event.is_set():  # but not on first sync
-            if current_block < self.unconfirmed_head_number:
-                log.info('Chain reorganization detected. '
-                         'Resyncing unconfirmed events (unconfirmed_head=%d) [@%d]' %
-                         (self.unconfirmed_head_number, self.web3.eth.blockNumber))
-                # here we should probably have a callback or a user-overriden method
-                self.unconfirmed_head_number = self.confirmed_head_number
-                self.unconfirmed_head_hash = self.confirmed_head_hash
-            try:
-                # raises if hash doesn't exist (i.e. block has been replaced)
-                self.web3.eth.getBlock(self.unconfirmed_head_hash)
-            except ValueError:
-                log.info(
-                    'Chain reorganization detected. '
-                    'Resyncing unconfirmed events (unconfirmed_head=%d) [@%d]. '
-                    '(getBlock() raised ValueError)' %
-                    (self.unconfirmed_head_number, current_block)
-                )
-                self.unconfirmed_head_number = self.confirmed_head_number
-                self.unconfirmed_head_hash = self.confirmed_head_hash
 
-            # in case of reorg longer than confirmation number fail
-            try:
-                self.web3.eth.getBlock(self.confirmed_head_hash)
-            except ValueError:
+            # block number increased or stayed the same
+            if current_block >= self.unconfirmed_head_number:
+                # if the hash of our head changed, there was a chain reorg
+                current_unconfirmed_hash = self.web3.eth.getBlock(
+                    self.unconfirmed_head_number
+                ).hash
+                if current_unconfirmed_hash != self.unconfirmed_head_hash:
+                    self._detected_chain_reorg(current_block)
+            # block number decreased, there was a chain reorg
+            elif current_block < self.unconfirmed_head_number:
+                self._detected_chain_reorg(current_block)
+
+            # now we have to check that the confirmed_head_hash stayed the same
+            current_confirmed_hash = self.web3.eth.getBlock(self.confirmed_head_number).hash
+            if current_confirmed_hash != self.confirmed_head_hash:
                 log.critical('Events considered confirmed have been reorganized')
                 assert False  # unreachable as long as confirmation level is set high enough
 
     # filter for events after block_number
     # to_block is incremented because eth-tester doesn't include events from the end block
     # see https://github.com/raiden-network/raiden/pull/1321
-    def get_filter_params(self, from_block, to_block):
+    def get_filter_params(self, from_block: int, to_block: int) -> Dict[str, int]:
         assert from_block <= to_block
         return {
             'from_block': from_block + 1,

--- a/raiden_libs/blockchain.py
+++ b/raiden_libs/blockchain.py
@@ -282,10 +282,23 @@ class BlockchainListener(gevent.Greenlet):
             try:
                 current_head_hash = self.web3.eth.getBlock(self.confirmed_head_number).hash
                 if current_head_hash != self.confirmed_head_hash:
-                    log.critical('Events considered confirmed have been reorganized')
+                    log.critical(
+                        'Events considered confirmed have been reorganized. '
+                        'Expected block hash %s for block number %d, but got block hash %s. '
+                        "The BlockchainListener's number of required confirmations is %d.",
+                        self.confirmed_head_hash,
+                        self.confirmed_head_number,
+                        current_head_hash,
+                        self.required_confirmations
+                    )
                     sys.exit(1)  # unreachable as long as confirmation level is set high enough
             except AttributeError:
-                log.critical('Events considered confirmed have been reorganized')
+                log.critical(
+                    'Events considered confirmed have been reorganized. '
+                    'The block %d with hash %s does not exist any more.',
+                    self.confirmed_head_number,
+                    self.confirmed_head_hash
+                )
                 sys.exit(1)  # unreachable as long as confirmation level is set high enough
 
     # filter for events after block_number

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 eth-utils>=1.0.1,<2.0
 coincurve>=7.1.0,<8.0
 web3>=4.0.0,<5.0
-py-evm==0.2.0a12
-eth-tester>=0.1.0-beta.21,<1.0
+eth-tester[py-evm]>=0.1.0-beta.23,<1.0
 pycryptodome>=3.5.1,<4.0
-ethereum
+ethereum>=2.3.1,<3.0
 gevent>=1.2.2,<2.0
 jsonschema

--- a/tests/test_blockchain_listener.py
+++ b/tests/test_blockchain_listener.py
@@ -1,40 +1,123 @@
 # -*- coding: utf-8 -*-
-import gevent
+import pytest
+from web3 import Web3
+
+from raiden_libs.blockchain import BlockchainListener
 
 
 def test_blockchain_listener(
+    web3: Web3,
+    wait_for_blocks,
     generate_raiden_clients,
-    blockchain_listener,
+    blockchain_listener: BlockchainListener,
     ethereum_tester,
 ):
-    """ Test confirmed and unconfirmed events. """
-    events_confirmed = []
-    events_unconfirmed = []
-    blockchain_listener.add_confirmed_listener(
-        'ChannelOpened',
-        lambda e: events_confirmed.append(e)
-    )
+    blockchain_listener.required_confirmations = 4
+    blockchain_listener.start()
+    blockchain_listener.wait_sync()
+
+    unconfirmed_channel_open_events = []
+    confirmed_channel_open_events = []
+
     blockchain_listener.add_unconfirmed_listener(
         'ChannelOpened',
-        lambda e: events_unconfirmed.append(e)
+        lambda e: unconfirmed_channel_open_events.append(e)
+    )
+    blockchain_listener.add_confirmed_listener(
+        'ChannelOpened',
+        lambda e: confirmed_channel_open_events.append(e)
     )
 
-    # start the blockchain listener
-    blockchain_listener.start()
-
+    # create unconfirmed channel
     c1, c2 = generate_raiden_clients(2)
     c1.open_channel(c2.address)
 
-    ethereum_tester.mine_block()
-    gevent.sleep()
+    # the unconfirmed event should be available directly
+    wait_for_blocks(0)
+    assert len(unconfirmed_channel_open_events) == 1
+    assert unconfirmed_channel_open_events[0]['args']['participant1'] == c1.address
+    assert unconfirmed_channel_open_events[0]['args']['participant2'] == c2.address
 
-    # the unconfirmed event should be received now
-    assert len(events_unconfirmed) == 1
+    # the confirmed event should be available after 4 more blocks as set above
+    wait_for_blocks(4)
+    assert len(confirmed_channel_open_events) == 1
+    assert confirmed_channel_open_events[0]['args']['participant1'] == c1.address
+    assert confirmed_channel_open_events[0]['args']['participant2'] == c2.address
 
-    # mine 3 more blocks, that should make the event confirmed
-    ethereum_tester.mine_blocks(3)
-    gevent.sleep()
+    blockchain_listener.stop()
 
-    assert len(events_confirmed) == 1
+
+def test_reorg(
+    web3: Web3,
+    wait_for_blocks,
+    generate_raiden_clients,
+    blockchain_listener: BlockchainListener,
+    ethereum_tester,
+):
+    blockchain_listener.required_confirmations = 5
+    blockchain_listener.start()
+    blockchain_listener.wait_sync()
+
+    unconfirmed_channel_open_events = []
+    blockchain_listener.add_unconfirmed_listener(
+        'ChannelOpened',
+        lambda e: unconfirmed_channel_open_events.append(e)
+    )
+
+    c1, c2 = generate_raiden_clients(2)
+    snapshot_id = web3.testing.snapshot()
+
+    # create unconfirmed channel
+    c1.open_channel(c2.address)
+    wait_for_blocks(0)
+    assert len(unconfirmed_channel_open_events) == 1
+    assert unconfirmed_channel_open_events[0]['args']['participant1'] == c1.address
+    assert unconfirmed_channel_open_events[0]['args']['participant2'] == c2.address
+
+    # remove unconfirmed channel opening with reorg
+    web3.testing.revert(snapshot_id)
+
+    # run the BlockchainListener again, it should have a lower head_number now
+    old_head_number = blockchain_listener.unconfirmed_head_number
+    wait_for_blocks(0)
+    new_head_number = blockchain_listener.unconfirmed_head_number
+
+    assert old_head_number > new_head_number
+
+    # test that a chain reorg of one block is handled
+    # this created a channel first, then reverts and creates a different channel
+    unconfirmed_channel_open_events.clear()
+    c1.open_channel(c2.address)
+    wait_for_blocks(0)
+    assert len(unconfirmed_channel_open_events) == 1
+    assert unconfirmed_channel_open_events[0]['args']['participant1'] == c1.address
+    assert unconfirmed_channel_open_events[0]['args']['participant2'] == c2.address
+    web3.testing.revert(snapshot_id)
+    c2.open_channel(c1.address)
+    wait_for_blocks(0)
+    assert len(unconfirmed_channel_open_events) == 2
+    assert unconfirmed_channel_open_events[1]['args']['participant1'] == c2.address
+    assert unconfirmed_channel_open_events[1]['args']['participant2'] == c1.address
+
+    web3.testing.revert(snapshot_id)
+
+    # test a big chain reorg (> required_confirmations)
+    confirmed_channel_open_events = []
+    blockchain_listener.add_confirmed_listener(
+        'ChannelOpened',
+        lambda e: confirmed_channel_open_events.append(e)
+    )
+    c1.open_channel(c2.address)
+
+    # create a new event and wait till it's confirmed
+    wait_for_blocks(5)
+
+    assert len(confirmed_channel_open_events) == 1
+
+    # revert the chain, this should kill the process
+    web3.testing.revert(snapshot_id)
+
+    with pytest.raises(SystemExit):
+        wait_for_blocks(0)
 
     blockchain_listener.stop()


### PR DESCRIPTION
@hackaugusto The code already tested for reorgs with block hashes as well, but it wasn't obvious. I think I managed to simplify the logic a bit.

Closes #25 