### PR TITLE
Contract wrapper that allows local signatures

### DIFF
--- a/raiden_libs/contract.py
+++ b/raiden_libs/contract.py
@@ -1,0 +1,110 @@
+from typing import List, Any
+
+import rlp
+from eth_utils import decode_hex, encode_hex, denoms
+from ethereum.transactions import Transaction
+from web3 import Web3
+from web3.contract import Contract
+
+from raiden_libs.utils import private_key_to_address, sign_transaction
+
+DEFAULT_TIMEOUT = 60
+DEFAULT_RETRY_INTERVAL = 3
+GAS_PRICE = 20 * denoms.gwei
+GAS_LIMIT_POT = 21000
+GAS_LIMIT_CONTRACT = 130000
+
+
+def create_signed_transaction(
+        private_key: str,
+        web3: Web3,
+        to: str,
+        value: int=0,
+        data=b'',
+        nonce_offset: int = 0,
+        gas_price: int = GAS_PRICE,
+        gas_limit: int = GAS_LIMIT_POT
+) -> str:
+    """Creates a signed on-chain transaction compliant with EIP155."""
+    tx = create_transaction(
+        web3=web3,
+        from_=private_key_to_address(private_key),
+        to=to,
+        value=value,
+        data=data,
+        nonce_offset=nonce_offset,
+        gas_price=gas_price,
+        gas_limit=gas_limit
+    )
+    sign_transaction(tx, private_key, int(web3.version.network))
+    return encode_hex(rlp.encode(tx))
+
+
+def create_transaction(
+        web3: Web3,
+        from_: str,
+        to: str,
+        data: bytes = b'',
+        nonce_offset: int = 0,
+        value: int = 0,
+        gas_price: int = GAS_PRICE,
+        gas_limit: int = GAS_LIMIT_POT
+) -> Transaction:
+    """Create a transaction"""
+    nonce = web3.eth.getTransactionCount(from_, 'pending') + nonce_offset
+    tx = Transaction(nonce, gas_price, gas_limit, to, value, data)
+    tx.sender = decode_hex(from_)
+    return tx
+
+
+def create_signed_contract_transaction(
+        private_key: str,
+        contract: Contract,
+        func_name: str,
+        args: List[Any],
+        value: int=0,
+        nonce_offset: int = 0,
+        gas_price: int = GAS_PRICE,
+        gas_limit: int = GAS_LIMIT_POT
+) -> str:
+    """Creates a signed on-chain contract transaction compliant with EIP155."""
+    tx = create_contract_transaction(
+        contract=contract,
+        from_=private_key_to_address(private_key),
+        func_name=func_name,
+        args=args,
+        value=value,
+        nonce_offset=nonce_offset,
+        gas_price=gas_price,
+        gas_limit=gas_limit
+    )
+    sign_transaction(tx, private_key, int(contract.web3.version.network))
+    return encode_hex(rlp.encode(tx))
+
+
+def create_contract_transaction(
+        contract: Contract,
+        from_: str,
+        func_name: str,
+        args: List[Any],
+        value: int = 0,
+        nonce_offset: int = 0,
+        gas_price: int = GAS_PRICE,
+        gas_limit: int = GAS_LIMIT_POT
+) -> Transaction:
+    data = create_transaction_data(contract, func_name, args)
+    return create_transaction(
+        web3=contract.web3,
+        from_=from_,
+        to=contract.address,
+        value=value,
+        data=data,
+        nonce_offset=nonce_offset,
+        gas_price=gas_price,
+        gas_limit=gas_limit
+    )
+
+
+def create_transaction_data(contract: Contract, func_name: str, args: List[Any]) -> bytes:
+    data = contract._prepare_transaction(func_name, args)['data']
+    return decode_hex(data)

--- a/raiden_libs/private_contract.py
+++ b/raiden_libs/private_contract.py
@@ -1,0 +1,64 @@
+from raiden_libs.contract import create_signed_transaction
+from web3.utils.abi import get_abi_output_types
+from eth_abi import decode_abi
+from eth_utils import decode_hex
+
+
+class Callable():
+    """Replaces web3.contract.ContractFunction in the contract.functions map"""
+    def __init__(self, call):
+        self._call = call
+
+    def prepare_tx(self, *args, **kwargs):
+        if len(args) == 1:
+            args[0].pop('from', None)
+        return self._call.buildTransaction(*args, **kwargs)
+
+    def transact(self, *args, **kwargs) -> bytes:
+        """Creates a transaction, signs it with a provided private key and sends it. """
+        private_key = kwargs.pop('private_key', None)
+        tx_data = self.prepare_tx(*args, **kwargs)
+        signed_tx = create_signed_transaction(
+            private_key,
+            self._call.web3,
+            tx_data['to'],
+            value=tx_data['value'],
+            data=decode_hex(tx_data['data']),
+            gas_limit=1300000
+        )
+        return self._call.web3.eth.sendRawTransaction(signed_tx)
+
+    def call(self, *args, **kwargs):
+        kwargs.pop('private_key', None)
+        if len(args) == 1:
+            args[0].pop('from', None)
+        tx = self._call.buildTransaction(*args, **kwargs)
+        output_types = get_abi_output_types(self._call.abi)
+        return_data = self._call.web3.eth.call(tx)
+        decoded = decode_abi(output_types, return_data)
+        return decoded[0] if len(decoded) == 1 else decoded
+
+
+class FunctionsMap:
+    """This replaces `function` attribute of the wrapped contract"""
+    def __init__(self, abi, contract):
+        self.contract = contract
+
+    def __getattr__(self, attr):
+        return lambda *args, **kwargs: self.get_call(attr, *args, **kwargs)
+
+    def get_call(self, attr, *args, **kwargs):
+        call = getattr(self.contract.functions, attr)(*args, **kwargs)
+        return Callable(call)
+
+
+class PrivateContract:
+    """This class allows using of web3.contract with a non-eth node account.
+    Usage:
+        contract = web3.eth.contract(abi=..., address=...)
+        wrapped_contract = PrivateContract(contract)
+        contract.functions.my_awesome_function().transact(private_key=my_key)
+    """
+    def __init__(self, contract):
+        self.contract = contract
+        self.functions = FunctionsMap(self.contract.abi, contract)

--- a/raiden_libs/test/fixtures/contracts.py
+++ b/raiden_libs/test/fixtures/contracts.py
@@ -54,13 +54,14 @@ def token_network_contract(
         secret_registry_contract,
         standard_token_contract
 ):
+    network_id = int(secret_registry_contract.web3.version.network)
     return deploy_tester_contract(
         'TokenNetwork',
         {
             'Token': standard_token_contract.address.encode(),
             'SecretRegistry': secret_registry_contract.address.encode()
         },
-        [standard_token_contract.address, secret_registry_contract.address]
+        [standard_token_contract.address, secret_registry_contract.address, network_id]
     )
 
 

--- a/raiden_libs/utils/signing.py
+++ b/raiden_libs/utils/signing.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+import rlp
 from typing import Union
 
 from coincurve import PrivateKey, PublicKey
+from ethereum.transactions import Transaction
 from eth_utils import (
     to_checksum_address,
     encode_hex,
@@ -101,3 +103,13 @@ def address_from_signature(sig: bytes, msg: bytes):
 
 def eth_verify(sig: bytes, msg: str) -> str:
     return address_from_signature(sig, keccak256(msg))
+
+
+def sign_transaction(tx: Transaction, privkey: str, network_id: int):
+    """Sign tx using EIP 155 signature."""
+    tx.v = network_id
+    sig = sign(privkey, keccak256(rlp.encode(tx)), v=35 + 2 * network_id)
+    v, r, s = sig[-1], sig[0:32], sig[32:-1]
+    tx.v = v
+    tx.r = int.from_bytes(r, byteorder='big')
+    tx.s = int.from_bytes(s, byteorder='big')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,6 @@ from raiden_libs.test.fixtures.client import *  # noqa
 from raiden_libs.test.fixtures.web3 import *  # noqa
 
 from .fixture_overwrites import *  # noqa
+
+from gevent import monkey
+monkey.patch_all()

--- a/tests/test_private_contract.py
+++ b/tests/test_private_contract.py
@@ -1,0 +1,18 @@
+from raiden_libs.private_contract import PrivateContract
+
+
+def test_private_contract(
+    standard_token_contract,
+    generate_raiden_clients,
+    wait_for_transaction
+):
+    client1, client2 = generate_raiden_clients(2)
+    private_contract = PrivateContract(standard_token_contract)
+    balance = private_contract.functions.balanceOf(client1.address).call()
+    tx_hash = private_contract.functions.transfer(client2.address, balance).transact(
+        private_key=client1.privkey
+    )
+
+    wait_for_transaction(tx_hash)
+    balance = private_contract.functions.balanceOf(client1.address).call()
+    assert balance == 0


### PR DESCRIPTION
- implements a wrapper for web3 contract that allows signing contract
  calls with a local private key
- can be removed once middleware signatures are merged to web3: https://github.com/ethereum/web3.py/pull/649