### PR TITLE
Remove unused parameter private_key

### DIFF
--- a/raiden_libs/messages/message.py
+++ b/raiden_libs/messages/message.py
@@ -35,7 +35,7 @@ class Message:
         assert isinstance(self._type, str)
         self._type = value
 
-    def serialize_full(self, private_key):
+    def serialize_full(self):
         """Serialize message to a standardized format, including message envelope"""
         msg = self.serialize_data()
         msg['message_type'] = self._type

--- a/raiden_libs/transport/transport.py
+++ b/raiden_libs/transport/transport.py
@@ -39,8 +39,10 @@ class Transport(gevent.Greenlet):
         # ignore if message is not a JSON
         try:
             json_msg = json.loads(data)
-        except json.decoder.JSONDecodeError:
+        except json.decoder.JSONDecodeError as ex:
+            log.error('Error when reading JSON: %s', str(ex))
             return
+
         # ignore message if JSON schema validation fails
         try:
             deserialized_msg = Message.deserialize(json_msg)
@@ -48,9 +50,10 @@ class Transport(gevent.Greenlet):
             jsonschema.exceptions.ValidationError,
             MessageSignatureError,
             MessageFormatError
-        ) as e:
-            log.warning('Error when deserializing message: %s' % str(e))
+        ) as ex:
+            log.error('Error when deserializing message: %s', str(ex))
             return
+
         for callback in self.message_callbacks:
             callback(deserialized_msg)
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -8,8 +8,7 @@ from raiden_libs.exceptions import MessageTypeError
 
 def test_serialize_deserialize(get_random_bp):
     bp = get_random_bp()
-    privkey = '0x1'
-    serialized_message = bp.serialize_full(privkey)
+    serialized_message = bp.serialize_full()
 
     deserialized_message = Message.deserialize(serialized_message)
     assert isinstance(deserialized_message, BalanceProof)


### PR DESCRIPTION
Removes the unused `private_key` parameter, that was probably used in the old message envelope.

Also fixes #47 