### PR TITLE
Adding request_path message

### DIFF
--- a/raiden_libs/messages/__init__.py
+++ b/raiden_libs/messages/__init__.py
@@ -2,10 +2,12 @@ from .message import Message
 from .balance_proof import BalanceProof
 from .monitor_request import MonitorRequest
 from .fee_info import FeeInfo
+from .paths_request import PathsRequest
 
 __all__ = [
     'Message',
     'BalanceProof',
     'MonitorRequest',
-    'FeeInfo'
+    'FeeInfo',
+    'PathsRequest'
 ]

--- a/raiden_libs/messages/balance_proof.py
+++ b/raiden_libs/messages/balance_proof.py
@@ -6,7 +6,7 @@ from eth_utils import is_address, decode_hex, encode_hex
 from raiden_libs.messages.message import Message
 from raiden_libs.properties import address_property
 from raiden_libs.messages.json_schema import BALANCE_PROOF_SCHEMA
-from raiden_libs.utils import eth_verify, pack_data
+from raiden_libs.utils import eth_verify, pack_data, UINT256_MAX
 from raiden_libs.types import Address, ChannelIdentifier
 
 
@@ -46,6 +46,8 @@ class BalanceProof(Message):
         self.signature = signature
 
         if transferred_amount and locked_amount and locksroot and balance_hash:
+            assert 0 <= transferred_amount <= UINT256_MAX
+            assert 0 <= locked_amount <= UINT256_MAX
             assert self.hash_balance_data(
                 transferred_amount,
                 locked_amount,

--- a/raiden_libs/messages/deserializer.py
+++ b/raiden_libs/messages/deserializer.py
@@ -5,10 +5,12 @@ def deserialize(message: Dict):
     from .balance_proof import BalanceProof
     from .monitor_request import MonitorRequest
     from .fee_info import FeeInfo
+    from .paths_request import PathsRequest
     type_to_class = {
         'BalanceProof': BalanceProof,
         'MonitorRequest': MonitorRequest,
         'FeeInfo': FeeInfo,
+        'PathsRequest': PathsRequest
     }
 
     message_type = message.pop('message_type')

--- a/raiden_libs/messages/json_schema.py
+++ b/raiden_libs/messages/json_schema.py
@@ -104,6 +104,46 @@ FEE_INFO_SCHEMA = {
     }
 }
 
+PATHS_REQUEST_SCHEMA = {
+    'type': 'object',
+    'required': [
+        'token_network_address',
+        'target_address',
+        'value',
+        'num_paths',
+        'chain_id',
+        'nonce',
+        'signature',
+    ],
+    'properties': {
+        'token_network_address': {
+            'type': 'string',
+        },
+        'target_address': {
+            'type': 'string',
+        },
+        'value': {
+            'type': 'integer',
+            'minimum': 1
+        },
+        'num_paths': {
+            'type': 'integer',
+            'minimum': 1
+        },
+        'chain_id': {
+            'type': 'integer',
+            'minimum': 1
+        },
+        'nonce': {
+            'type': 'integer',
+            'minimum': 0
+        },
+        'signature': {
+            'type': 'string'
+        },
+    }
+}
+
 ENVELOPE_SCHEMA = {
     'type': 'object',
     'required': ['message_type'],

--- a/raiden_libs/test/mocks/client.py
+++ b/raiden_libs/test/mocks/client.py
@@ -10,7 +10,7 @@ from web3.contract import Contract
 from raiden_contracts.contract_manager import get_event_from_abi
 
 from raiden_libs.utils import private_key_to_address, make_filter, sign_data
-from raiden_libs.messages import BalanceProof, MonitorRequest, FeeInfo
+from raiden_libs.messages import BalanceProof, MonitorRequest, FeeInfo, PathsRequest
 from raiden_libs.types import Address, ChannelIdentifier
 
 
@@ -271,6 +271,22 @@ class MockRaidenNode:
         )
         fi.signature = encode_hex(sign_data(self.privkey, fi.serialize_bin()))
         return fi
+
+    def request_paths(self, target_address: Address, **kwargs) -> PathsRequest:
+        """Generate a PathsRequest for pathfinding-service .
+        Parameters:
+            target_address: address of the transaction target, this method is agnostic
+            that this is verified.
+            **kwargs: arguments to FeeInfo constructor
+        """
+        # FIXME implement a nonce is necessary for replay protection
+        request = PathsRequest(
+            self.contract.address,
+            target_address,
+            **kwargs
+        )
+        request.signature = encode_hex(sign_data(self.privkey, request.serialize_bin()))
+        return request
 
     @assert_channel_existence
     def update_transfer(self, partner_address: Address, balance_proof: BalanceProof):

--- a/tests/test_client_mock.py
+++ b/tests/test_client_mock.py
@@ -21,13 +21,13 @@ def test_client_fee_info(generate_raiden_clients):
     channel_id = c1.open_channel(c2.address)
     assert channel_id > 0
 
-    fi = c1.get_fee_info(c2.address, nonce=5, percentage_fee=0.1, chain_id=2)
+    fi = c1.get_fee_info(c2.address, nonce=5, percentage_fee='0.1', chain_id=2)
     fee_info_signer = eth_verify(decode_hex(fi.signature), fi.serialize_bin())
 
     assert is_same_address(fee_info_signer, c1.address)
 
     assert fi.nonce == 5
-    assert isclose(fi.percentage_fee, 0.1)
+    assert isclose(float(fi.percentage_fee), 0.1)
     assert fi.chain_id == 2
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -97,9 +97,24 @@ def test_fee_info():
         percentage_fee='0.1',
         signature='signature'
     )
+    assert message == Message.deserialize(message).serialize_data()
+    message['message_type'] = 'FeeInfo'
+    assert isinstance(Message.deserialize(message), FeeInfo)
 
-    deserialized_message = Message.deserialize(message)
-    assert isinstance(deserialized_message, FeeInfo)
+
+def test_request_paths():
+    message: Dict = dict(
+        message_type='PathsRequest',
+        token_network_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
+        target_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
+        value=1000,
+        num_paths=1,
+        chain_id=1,
+        nonce=1,
+        signature='signature'
+    )
+
+    assert message == Message.deserialize(message).serialize_data()
 
 
 def test_deserialize_with_required_type():
@@ -116,7 +131,7 @@ def test_deserialize_with_required_type():
     deserialized_message = Message.deserialize(message, FeeInfo)
     assert isinstance(deserialized_message, FeeInfo)
 
-    # during deseriaisation the `message_type`is removed, add it back
+    # during deserialization the `message_type` is removed, add it back
     message['message_type'] = 'FeeInfo'
     with pytest.raises(MessageTypeError):
         Message.deserialize(message, BalanceProof)


### PR DESCRIPTION
Implementing a message and a method for mocks/client to request paths (Client -> PFS).
Updating fee_info with web3 compliant serialize_bin.
Introducing a string fix for percentage_fee type. This is to be fixed.