### PR TITLE
Update monitor request to use new BP

### DIFF
--- a/raiden_libs/messages/balance_proof.py
+++ b/raiden_libs/messages/balance_proof.py
@@ -22,9 +22,9 @@ class BalanceProof(Message):
 
         balance_hash: str = None,
         nonce: int = 0,
-        additional_hash: str = '',
+        additional_hash: str = None,
         chain_id: int = 1,
-        signature: str = '',
+        signature: str = None,
 
         transferred_amount: int = None,
         locked_amount: int = None,

--- a/raiden_libs/messages/monitor_request.py
+++ b/raiden_libs/messages/monitor_request.py
@@ -14,7 +14,6 @@ class MonitorRequest(Message):
     call MSC
     """
     reward_sender_address = address_property('_reward_sender_address')  # type: ignore
-    token_network_address = address_property('_token_network_address')  # type: ignore
     monitor_address = address_property('_monitor_address')  # type: ignore
     _type = 'MonitorRequest'
 
@@ -59,12 +58,12 @@ class MonitorRequest(Message):
             'uint8',
             'address'
         ], [
-            self.balance_proof.channel_identifier.to_bytes(32, byteorder='big'),
-            self.reward_amount.to_bytes(24, byteorder='big'),
-            decode_hex(self.balance_proof.token_network_address),
-            self.balance_proof.chain_id.to_bytes(32, byteorder='big'),
-            self.balance_proof.nonce.to_bytes(8, byteorder='big'),
-            decode_hex(self.monitor_address)
+            self.balance_proof.channel_identifier,
+            self.reward_amount,
+            self.balance_proof.token_network_address,
+            self.balance_proof.chain_id,
+            self.balance_proof.nonce,
+            self.monitor_address
         ])
 
     @classmethod

--- a/raiden_libs/test/fixtures/__init__.py
+++ b/raiden_libs/test/fixtures/__init__.py
@@ -1,0 +1,19 @@
+import pytest
+from eth_tester.validation.common import validate_positive_integer
+from eth_tester.exceptions import ValidationError
+
+
+def patched_validate_signature_v(value):
+    validate_positive_integer(value)
+    if value not in {0, 1, 27, 28, 37, 38}:
+        raise ValidationError(
+            "The `v` portion of the signature must be 0, 1, 27, 28, 37 or 38, not %d"
+            % value
+        )
+
+
+@pytest.fixture(autouse=True)
+def patch_validate_signature_v():
+    import eth_tester.validation.outbound as outbound
+    outbound.validate_signature_v = patched_validate_signature_v
+    outbound.TRANSACTION_VALIDATORS['v'] = patched_validate_signature_v

--- a/raiden_libs/test/mocks/client.py
+++ b/raiden_libs/test/mocks/client.py
@@ -250,6 +250,10 @@ class MockRaidenNode:
                 monitor_request.serialize_reward_proof()
             )
         )
+        non_closing_data = balance_proof.serialize_bin() + decode_hex(balance_proof.signature)
+        monitor_request.non_closing_signature = encode_hex(
+            sign_data(self.privkey, non_closing_data)
+        )
         return monitor_request
 
     @assert_channel_existence

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -9,8 +9,15 @@ from raiden_libs.exceptions import MessageTypeError
 from raiden_libs.types import Address, ChannelIdentifier
 
 
-def test_serialize_deserialize(get_random_bp):
+def test_serialize_deserialize(get_random_bp, get_random_privkey):
     bp = get_random_bp()
+    privkey = get_random_privkey()
+    bp.signature = encode_hex(
+        sign_data(
+            privkey,
+            bp.serialize_bin()
+        )
+    )
     serialized_message = bp.serialize_full()
 
     deserialized_message = Message.deserialize(serialized_message)


### PR DESCRIPTION
- non_closing_signature is generated by the mocked client
- added patching of eth_tester to allow privately signed txs
- update binary serialization of MonitorRequest