### PR TITLE
adding paths_reply message

### DIFF
--- a/raiden_libs/messages/__init__.py
+++ b/raiden_libs/messages/__init__.py
@@ -3,11 +3,13 @@ from .balance_proof import BalanceProof
 from .monitor_request import MonitorRequest
 from .fee_info import FeeInfo
 from .paths_request import PathsRequest
+from .paths_reply import PathsReply
 
 __all__ = [
     'Message',
     'BalanceProof',
     'MonitorRequest',
     'FeeInfo',
-    'PathsRequest'
+    'PathsRequest',
+    'PathsReply'
 ]

--- a/raiden_libs/messages/deserializer.py
+++ b/raiden_libs/messages/deserializer.py
@@ -6,11 +6,13 @@ def deserialize(message: Dict):
     from .monitor_request import MonitorRequest
     from .fee_info import FeeInfo
     from .paths_request import PathsRequest
+    from .paths_reply import PathsReply
     type_to_class = {
         'BalanceProof': BalanceProof,
         'MonitorRequest': MonitorRequest,
         'FeeInfo': FeeInfo,
-        'PathsRequest': PathsRequest
+        'PathsRequest': PathsRequest,
+        'PathsReply': PathsReply,
     }
 
     message_type = message.pop('message_type')

--- a/raiden_libs/messages/json_schema.py
+++ b/raiden_libs/messages/json_schema.py
@@ -145,6 +145,50 @@ PATHS_REQUEST_SCHEMA = {
     }
 }
 
+PATHS_REPLY_SCHEMA = {
+    'type': 'object',
+    'required': [
+        'token_network_address',
+        'target_address',
+        'value',
+        'num_paths',
+        'chain_id',
+        'nonce',
+        'paths_and_fees',
+        'signature',
+    ],
+    'properties': {
+        'token_network_address': {
+            'type': 'string',
+        },
+        'target_address': {
+            'type': 'string',
+        },
+        'value': {
+            'type': 'integer',
+            'minimum': 1
+        },
+        'num_paths': {
+            'type': 'integer',
+            'minimum': 1
+        },
+        'chain_id': {
+            'type': 'integer',
+            'minimum': 1
+        },
+        'nonce': {
+            'type': 'integer',
+            'minimum': 0
+        },
+        'paths_and_fees': {
+            'type': 'array',
+        },
+        'signature': {
+            'type': 'string'
+        },
+    }
+}
+
 ENVELOPE_SCHEMA = {
     'type': 'object',
     'required': ['message_type'],

--- a/raiden_libs/messages/paths_reply.py
+++ b/raiden_libs/messages/paths_reply.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+from typing import Dict
+
+import jsonschema
+from eth_utils import is_address, decode_hex
+
+from raiden_libs.messages.message import Message
+from raiden_libs.properties import address_property
+from raiden_libs.messages.json_schema import PATHS_REPLY_SCHEMA
+from raiden_libs.utils import eth_verify, UINT256_MAX, pack_data
+from raiden_libs.types import Address
+
+
+class PathsReply(Message):
+    """ A message to request a path from PFS. It is sent from a raiden node to the PFS. """
+    def __init__(
+        self,
+        token_network_address: Address,
+        target_address: Address,
+        value: int,
+        chain_id: int,
+        num_paths: int,
+        nonce: int,
+        paths_and_fees: list = None,
+        signature: str = None
+
+    ) -> None:
+        super().__init__()
+        assert is_address(token_network_address)
+        assert is_address(target_address)
+        assert 0 <= value <= UINT256_MAX
+        assert 0 <= num_paths <= UINT256_MAX
+        assert 0 <= nonce <= UINT256_MAX
+
+        self._type = 'PathsReply'
+        self.token_network_address = token_network_address
+        self.target_address = target_address
+        self.value = value
+        self.num_paths = num_paths
+        self.chain_id = chain_id
+        self.nonce = nonce
+        self.paths_and_fees = paths_and_fees
+        self.signature = signature
+
+    def serialize_data(self) -> Dict:
+        return {
+            'token_network_address': self.token_network_address,
+            'target_address': self.target_address,
+            'value': self.value,
+            'num_paths': self.num_paths,
+            'chain_id': self.chain_id,
+            'nonce': self.nonce,
+            'paths_and_fees': self.paths_and_fees,
+            'signature': self.signature,
+        }
+
+    def serialize_bin(self):
+        """Returns PathsReply serialized to binary"""
+        return pack_data([
+            'address',
+            'address',
+            'uint256',
+            'uint256',
+            'uint256',
+            'uint256',
+            'array',
+            'signature',
+        ], [
+            self.token_network_address,
+            self.target_address,
+            self.value,
+            self.num_paths,
+            self.chain_id,
+            self.nonce,
+            self.paths_and_fees,
+            self.signature,
+        ])
+
+    @classmethod
+    def deserialize(cls, data):
+        jsonschema.validate(data, PATHS_REPLY_SCHEMA)
+        ret = cls(
+            token_network_address=data['token_network_address'],
+            target_address=data['target_address'],
+            value=data['value'],
+            num_paths=data['num_paths'],
+            chain_id=data['chain_id'],
+            nonce=data['nonce'],
+            paths_and_fees=data['paths_and_fees'],
+            signature=data['signature'],
+        )
+
+        return ret
+
+    @property
+    def signer(self) -> str:
+        return eth_verify(
+            decode_hex(self.signature),
+            self.serialize_bin()
+        )
+
+    token_network_address = address_property('_contract')  # type: ignore
+    json_schema = PATHS_REPLY_SCHEMA

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pycryptodome>=3.5.1,<4.0
 ethereum>=2.3.1,<3.0
 gevent>=1.2.2,<2.0
 jsonschema
+
+git+https://github.com/matrix-org/matrix-python-sdk.git

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,7 +4,14 @@ import pytest
 from eth_utils import is_same_address
 
 from raiden_libs.utils import sign_data, private_key_to_address, encode_hex
-from raiden_libs.messages import BalanceProof, Message, FeeInfo, MonitorRequest
+from raiden_libs.messages import (
+    BalanceProof,
+    Message,
+    FeeInfo,
+    MonitorRequest,
+    PathsRequest,
+    PathsReply
+)
 from raiden_libs.exceptions import MessageTypeError
 from raiden_libs.types import Address, ChannelIdentifier
 
@@ -103,7 +110,7 @@ def test_fee_info():
     assert isinstance(Message.deserialize(message), FeeInfo)
 
 
-def test_request_paths():
+def test_paths_request():
     message: Dict = dict(
         message_type='PathsRequest',
         token_network_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
@@ -116,6 +123,29 @@ def test_request_paths():
     )
 
     assert message == Message.deserialize(message).serialize_data()
+    message['message_type'] = 'PathsRequest'
+    assert isinstance(Message.deserialize(message), PathsRequest)
+
+
+def test_paths_reply():
+    message: Dict = dict(
+        message_type='PathsReply',
+        token_network_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
+        target_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
+        value=1000,
+        num_paths=1,
+        chain_id=1,
+        nonce=1,
+        paths_and_fees=[{
+            'estimated_fee': 10000,
+            'paths': [['0x82dd0e0eA3E84D00Cc119c46Ee220609', '0xA3E84D00Cc119c46Ee22060939E5D1FC']]
+        }],
+        signature='signature'
+    )
+
+    assert message == Message.deserialize(message).serialize_data()
+    message['message_type'] = 'PathsReply'
+    assert isinstance(Message.deserialize(message), PathsReply)
 
 
 def test_deserialize_with_required_type():


### PR DESCRIPTION
Adding `paths_reply` message type for PFS -> Client. Additionally adding `DummyTransport` to `MockRaidenNode` to process messages received from PFS.