### PR TITLE
Update BalanceProof defaults

### DIFF
--- a/raiden_libs/messages/monitor_request.py
+++ b/raiden_libs/messages/monitor_request.py
@@ -27,7 +27,7 @@ class MonitorRequest(Message):
         monitor_address: Address = None
     ) -> None:
         assert non_closing_signature is None or len(decode_hex(non_closing_signature)) == 65
-        assert (reward_amount >= 0) and (reward_amount <= UINT192_MAX)
+        assert reward_amount is None or (reward_amount >= 0) and (reward_amount <= UINT192_MAX)
         # todo: validate reward proof signature
         assert is_address(reward_sender_address)
         assert is_address(monitor_address)

--- a/raiden_libs/test/fixtures/address.py
+++ b/raiden_libs/test/fixtures/address.py
@@ -62,24 +62,25 @@ def get_random_bp(get_random_address) -> Callable:
 @pytest.fixture
 def get_random_monitor_request(get_random_bp, get_random_address, get_random_privkey):
     def f():
-        bp = get_random_bp()
+        balance_proof = get_random_bp()
         privkey = get_random_privkey()
-        bp.signature = encode_hex(sign_data(privkey, bp.serialize_bin()))
-        mr = MonitorRequest(
-            bp.channel_id,
-            bp.nonce,
-            bp.transferred_amount,
-            bp.locksroot,
-            bp.extra_hash,
-            bp.signature,
+        privkey_non_closing = get_random_privkey()
+        balance_proof.signature = encode_hex(sign_data(privkey, balance_proof.serialize_bin()))
+        non_closing_signature = encode_hex(
+            sign_data(privkey_non_closing, balance_proof.serialize_bin())
+        )
+
+        monitor_request = MonitorRequest(
+            balance_proof,
+            non_closing_signature,
             reward_sender_address=get_random_address(),
             reward_amount=random.randint(0, UINT192_MAX),
-            token_network_address=get_random_address(),
-            chain_id=random.randint(0, UINT256_MAX),
             monitor_address=get_random_address()
         )
-        mr.reward_proof_signature = encode_hex(sign_data(privkey, mr.serialize_reward_proof()))
-        return mr
+        monitor_request.reward_proof_signature = encode_hex(
+            sign_data(privkey, monitor_request.serialize_reward_proof())
+        )
+        return monitor_request
     return f
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -36,14 +36,14 @@ def test_balance_proof_address_setter(get_random_bp):
 
 
 def test_balance_proof():
+    # test balance proof with computed balance hash
     balance_proof = BalanceProof(
         channel_identifier=ChannelIdentifier(123),
         token_network_address=Address('0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC'),
         nonce=1,
         chain_id=321,
-        balance_hash='0x%064x' % 5,
-        transferred_amount=1,
-        locked_amount=0,
+        transferred_amount=5,
+        locksroot='0x%064x' % 5,
         additional_hash='0x%064x' % 0,
     )
     serialized = balance_proof.serialize_data()
@@ -58,20 +58,24 @@ def test_balance_proof():
     assert serialized['additional_hash'] == balance_proof.additional_hash
     assert serialized['balance_hash'] == balance_proof.balance_hash
 
-    with pytest.raises(KeyError):
-        serialized['transferred_amount']
+    assert serialized['locksroot'] == balance_proof.locksroot
+    assert serialized['transferred_amount'] == balance_proof.transferred_amount
+    assert serialized['locked_amount'] == balance_proof.locked_amount
 
+    # test balance proof with balance hash set from constructor
     balance_proof = BalanceProof(
         channel_identifier=ChannelIdentifier(123),
         token_network_address=Address('0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC'),
         nonce=1,
         chain_id=321,
-        locksroot='0x%064x' % 5,
-        transferred_amount=1,
+        balance_hash='0x%064x' % 5,
         locked_amount=0,
         additional_hash='0x%064x' % 0,
     )
     serialized = balance_proof.serialize_data()
+
+    with pytest.raises(KeyError):
+        serialized['transferred_amount']
 
     assert serialized['channel_identifier'] == balance_proof.channel_identifier
     assert is_same_address(
@@ -81,10 +85,7 @@ def test_balance_proof():
     assert serialized['nonce'] == balance_proof.nonce
     assert serialized['chain_id'] == balance_proof.chain_id
     assert serialized['additional_hash'] == balance_proof.additional_hash
-
-    assert serialized['locksroot'] == balance_proof.locksroot
-    assert serialized['transferred_amount'] == balance_proof.transferred_amount
-    assert serialized['locked_amount'] == balance_proof.locked_amount
+    assert serialized['balance_hash'] == balance_proof.balance_hash
 
 
 def test_fee_info():


### PR DESCRIPTION
- this updates BP constructor defaults for locked_amount and locksroot
- adds test for settling the channel without `updateTransfer` being
  called prior to settle