### PR TITLE
Add contract_deploy_txhash fixture

### DIFF
--- a/raiden_libs/test/fixtures/contracts.py
+++ b/raiden_libs/test/fixtures/contracts.py
@@ -49,6 +49,30 @@ def deploy_tester_contract(
 
 
 @pytest.fixture
+def deploy_tester_contract_txhash(
+        web3,
+        contracts_manager,
+        deploy_contract_txhash,
+        contract_deployer_address,
+        wait_for_transaction,
+        get_random_address
+):
+    """Returns a function that can be used to deploy a named contract,
+    but returning txhash only"""
+    def f(contract_name, libs=None, args=list()):
+        json_contract = contracts_manager.compile_contract(contract_name, libs)
+        txhash = deploy_contract_txhash(
+            web3,
+            contract_deployer_address,
+            json_contract['abi'],
+            json_contract['bin'],
+            args
+        )
+        return txhash
+    return f
+
+
+@pytest.fixture
 def token_network_contract(
         deploy_tester_contract,
         secret_registry_contract,

--- a/raiden_libs/test/fixtures/web3.py
+++ b/raiden_libs/test/fixtures/web3.py
@@ -30,7 +30,22 @@ def ethereum_tester():
 
 
 @pytest.fixture
-def deploy_contract(revert_chain):
+def deploy_contract_txhash(revert_chain):
+    """Returns a function that deploys a compiled contract, returning a txhash"""
+    def fn(
+            web3,
+            deployer_address,
+            abi,
+            bytecode,
+            args
+    ):
+        contract = web3.eth.contract(abi=abi, bytecode=bytecode)
+        return contract.constructor(*args).transact({'from': deployer_address})
+    return fn
+
+
+@pytest.fixture
+def deploy_contract(revert_chain, deploy_contract_txhash):
     """Returns a function that deploys a compiled contract"""
     def fn(
             web3,
@@ -40,7 +55,7 @@ def deploy_contract(revert_chain):
             args
     ):
         contract = web3.eth.contract(abi=abi, bytecode=bytecode)
-        txhash = contract.constructor(*args).transact({'from': deployer_address})
+        txhash = deploy_contract_txhash(web3, deployer_address, abi, bytecode, args)
         contract_address = web3.eth.getTransactionReceipt(txhash).contractAddress
         web3.testing.mine(1)
 


### PR DESCRIPTION
- add fixture that returns txhash of a deployed contract (required for
  some tests in `raiden-contracts` repo)