### PR TITLE
Adjust to the new channel identifier

### DIFF
--- a/raiden_libs/messages/balance_proof.py
+++ b/raiden_libs/messages/balance_proof.py
@@ -7,7 +7,7 @@ from raiden_libs.messages.message import Message
 from raiden_libs.properties import address_property
 from raiden_libs.messages.json_schema import BALANCE_PROOF_SCHEMA
 from raiden_libs.utils import eth_verify, pack_data, UINT256_MAX
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden_libs.types import Address, ChannelIdentifier, T_ChannelIdentifier
 
 
 class BalanceProof(Message):
@@ -35,7 +35,7 @@ class BalanceProof(Message):
         locksroot: str = '0x%064x' % 0
     ) -> None:
         super().__init__()
-        assert channel_identifier > 0
+        assert isinstance(channel_identifier, T_ChannelIdentifier)
         assert is_address(token_network_address)
 
         self._type = 'BalanceProof'
@@ -86,14 +86,14 @@ class BalanceProof(Message):
             'bytes32',
             'uint256',
             'bytes32',
-            'uint256',
+            'bytes32',
             'address',
             'uint256'
         ], [
             decode_hex(self.balance_hash),
             self.nonce,
             decode_hex(self.additional_hash),
-            self.channel_identifier,
+            decode_hex(self.channel_identifier),
             self.token_network_address,
             self.chain_id
         ])

--- a/raiden_libs/messages/fee_info.py
+++ b/raiden_libs/messages/fee_info.py
@@ -8,7 +8,7 @@ from raiden_libs.messages.message import Message
 from raiden_libs.properties import address_property
 from raiden_libs.messages.json_schema import FEE_INFO_SCHEMA
 from raiden_libs.utils import eth_verify, pack_data
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden_libs.types import Address, ChannelIdentifier, T_ChannelIdentifier
 
 
 class FeeInfo(Message):
@@ -29,7 +29,7 @@ class FeeInfo(Message):
                 corresponds to a relative fee of one percent.
         """
         super().__init__()
-        assert channel_identifier >= 0
+        assert isinstance(channel_identifier, T_ChannelIdentifier)
         assert is_address(token_network_address)
 
         self._type = 'FeeInfo'
@@ -55,13 +55,13 @@ class FeeInfo(Message):
         """Return FeeInfo serialized to binary"""
         return pack_data([
             'address',
-            'uint256',
+            'bytes32',
             'uint256',
             'uint256',
             'uint256'
         ], [
             self.token_network_address,
-            self.channel_identifier,
+            decode_hex(self.channel_identifier),
             self.chain_id,
             self.nonce,
             self.relative_fee,

--- a/raiden_libs/messages/json_schema.py
+++ b/raiden_libs/messages/json_schema.py
@@ -15,7 +15,7 @@ BALANCE_PROOF_SCHEMA = {
     ],
     'properties': {
         'channel_identifier': {
-            'type': 'integer',
+            'type': 'string',
         },
         'nonce': {
             'type': 'integer',
@@ -88,8 +88,7 @@ FEE_INFO_SCHEMA = {
             'type': 'integer',
         },
         'channel_identifier': {
-            'type': 'integer',
-            'minimum': 1
+            'type': 'string',
         },
         'nonce': {
             'type': 'integer',

--- a/raiden_libs/test/fixtures/address.py
+++ b/raiden_libs/test/fixtures/address.py
@@ -34,14 +34,14 @@ def get_random_address(get_random_privkey) -> Callable:
 
 
 @pytest.fixture
-def get_random_bp(get_random_address) -> Callable:
+def get_random_bp(get_random_address, get_random_privkey) -> Callable:
     """Returns a balance proof filled in with a random value"""
     def f(
         channel_identifier: ChannelIdentifier = None,
         contract_address: Address = None
     ):
         contract_address = contract_address or get_random_address()
-        channel_identifier = channel_identifier or ChannelIdentifier(random.randint(0, UINT64_MAX))
+        channel_identifier = channel_identifier or ChannelIdentifier(get_random_privkey())
 
         balance_hash_data = '%d' % random.randint(0, UINT64_MAX)
         additional_hash_data = '%d' % random.randint(0, UINT64_MAX)

--- a/raiden_libs/types.py
+++ b/raiden_libs/types.py
@@ -4,5 +4,5 @@ from typing import NewType
 T_Address = str
 Address = NewType('Address', T_Address)
 
-T_ChannelIdentifier = int
+T_ChannelIdentifier = str
 ChannelIdentifier = NewType('ChannelIdentifier', T_ChannelIdentifier)

--- a/tests/test_client_mock.py
+++ b/tests/test_client_mock.py
@@ -3,13 +3,20 @@ import pytest
 from eth_utils import decode_hex, is_same_address
 
 from raiden_libs.utils.signing import eth_verify
+from raiden_libs.types import ChannelIdentifier, T_ChannelIdentifier
+
+
+def is_channel_identifier(channel_identifier: ChannelIdentifier):
+    assert isinstance(channel_identifier, T_ChannelIdentifier)
+    return len(decode_hex(channel_identifier)) == 32
 
 
 def test_client_multiple_topups(generate_raiden_clients):
     deposits = [1, 1, 2, 3, 5, 8, 13]
     c1, c2 = generate_raiden_clients(2)
-    channel_id = c1.open_channel(c2.address)
-    assert channel_id > 0
+    channel_identifier = c1.open_channel(c2.address)
+    assert is_channel_identifier(channel_identifier)
+
     [c1.deposit_to_channel(c2.address, x) for x in deposits]
     channel_info = c1.get_own_channel_info(c2.address)
     assert sum(deposits) == channel_info['deposit']
@@ -17,8 +24,8 @@ def test_client_multiple_topups(generate_raiden_clients):
 
 def test_client_fee_info(generate_raiden_clients):
     c1, c2 = generate_raiden_clients(2)
-    channel_id = c1.open_channel(c2.address)
-    assert channel_id > 0
+    channel_identifier = c1.open_channel(c2.address)
+    assert is_channel_identifier(channel_identifier)
 
     fi = c1.get_fee_info(c2.address, nonce=5, relative_fee=1000, chain_id=2)
     fee_info_signer = eth_verify(decode_hex(fi.signature), fi.serialize_bin())

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -45,7 +45,9 @@ def test_balance_proof_address_setter(get_random_bp):
 def test_balance_proof():
     # test balance proof with computed balance hash
     balance_proof = BalanceProof(
-        channel_identifier=ChannelIdentifier(123),
+        channel_identifier=ChannelIdentifier(
+            '0x3131313131313131313131313131313131313131313131313131313131313131'
+        ),
         token_network_address=Address('0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC'),
         nonce=1,
         chain_id=321,
@@ -71,7 +73,9 @@ def test_balance_proof():
 
     # test balance proof with balance hash set from constructor
     balance_proof = BalanceProof(
-        channel_identifier=ChannelIdentifier(123),
+        channel_identifier=ChannelIdentifier(
+            '0x3131313131313131313131313131313131313131313131313131313131313131'
+        ),
         token_network_address=Address('0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC'),
         nonce=1,
         chain_id=321,
@@ -100,7 +104,7 @@ def test_fee_info():
         message_type='FeeInfo',
         token_network_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
         chain_id=1,
-        channel_identifier=123,
+        channel_identifier='0x3131313131313131313131313131313131313131313131313131313131313131',
         nonce=1,
         relative_fee=10000,
         signature='signature'
@@ -153,7 +157,7 @@ def test_deserialize_with_required_type():
         message_type='FeeInfo',
         token_network_address='0x82dd0e0eA3E84D00Cc119c46Ee22060939E5D1FC',
         chain_id=1,
-        channel_identifier=123,
+        channel_identifier='0x3131313131313131313131313131313131313131313131313131313131313131',
         nonce=1,
         relative_fee=1000,
         signature='signature'


### PR DESCRIPTION
I store the `channel_identifier` as `bytes` right now, but it might be nicer to switch to a `str`. Let me know what you think.