### PR TITLE
Add `is_channel_identifier()` to utils

### DIFF
--- a/raiden_libs/utils/__init__.py
+++ b/raiden_libs/utils/__init__.py
@@ -2,8 +2,15 @@ from .merkle import *  # noqa
 from .contracts import *  # noqa
 from .signing import *  # noqa
 from .private_key import *  # noqa
+from raiden_libs.types import ChannelIdentifier, T_ChannelIdentifier
+from eth_utils import decode_hex
 
 
 UINT64_MAX = (2**64) - 1
 UINT192_MAX = (2**192) - 1
 UINT256_MAX = (2**256) - 1
+
+
+def is_channel_identifier(channel_identifier: ChannelIdentifier):
+    assert isinstance(channel_identifier, T_ChannelIdentifier)
+    return len(decode_hex(channel_identifier)) == 32

--- a/tests/test_client_mock.py
+++ b/tests/test_client_mock.py
@@ -3,12 +3,7 @@ import pytest
 from eth_utils import decode_hex, is_same_address
 
 from raiden_libs.utils.signing import eth_verify
-from raiden_libs.types import ChannelIdentifier, T_ChannelIdentifier
-
-
-def is_channel_identifier(channel_identifier: ChannelIdentifier):
-    assert isinstance(channel_identifier, T_ChannelIdentifier)
-    return len(decode_hex(channel_identifier)) == 32
+from raiden_libs.utils import is_channel_identifier
 
 
 def test_client_multiple_topups(generate_raiden_clients):


### PR DESCRIPTION
- moves `is_channel_identifier` to utils, as it is quite useful to have it available in other projects