### PR TITLE
Add DummyNetwork to dispatch messages to other nodes

### DIFF
--- a/raiden_libs/test/fixtures/client.py
+++ b/raiden_libs/test/fixtures/client.py
@@ -1,5 +1,9 @@
+from typing import List
+
 import pytest
+
 from raiden_libs.test.mocks.client import MockRaidenNode
+from raiden_libs.test.mocks.dummy_transport import DummyTransport, DummyNetwork
 
 
 @pytest.fixture
@@ -35,4 +39,23 @@ def generate_raiden_clients(generate_raiden_client):
     """Factory function to generate a list of raiden clients."""
     def f(count=1):
         return [generate_raiden_client() for x in range(count)]
+    return f
+
+
+@pytest.fixture
+def generate_dummy_network(generate_raiden_clients):
+    """Factory function to generate a DummyNetwork full of Raiden clients with DummyTransports."""
+    def f(count=2):
+        clients: List[MockRaidenNode] = generate_raiden_clients(count)
+
+        network = DummyNetwork()
+
+        for client in clients:
+            transport = DummyTransport(network)
+            network.add_transport(client.address, transport)
+
+            client.transport = transport
+
+        return network, clients
+
     return f

--- a/raiden_libs/test/mocks/client.py
+++ b/raiden_libs/test/mocks/client.py
@@ -76,7 +76,7 @@ class MockRaidenNode:
         self.token_network_abi = None
         self.client_registry: Dict[Address, 'MockRaidenNode'] = dict()
         self.web3 = self.contract.web3
-        self.transport = transport
+        self._transport = transport
         self.paths_and_fees = None
 
     def on_message_event(self, message: Message):
@@ -358,7 +358,12 @@ class MockRaidenNode:
             for field in return_fields
         }
 
-    def set_transport_callback(self):
-        """To be called if a transport is used."""
-        assert self.transport is not None
-        self.transport.add_message_callback(self.on_message_event)
+    @property
+    def transport(self):
+        return self._transport
+
+    @transport.setter
+    def transport(self, value: Transport):
+        assert value is not None
+        self._transport = value
+        self._transport.add_message_callback(self.on_message_event)

--- a/raiden_libs/test/mocks/dummy_transport.py
+++ b/raiden_libs/test/mocks/dummy_transport.py
@@ -1,3 +1,4 @@
+from typing import List, Dict
 from collections import defaultdict
 
 import gevent
@@ -5,13 +6,28 @@ import gevent
 from raiden_libs.transport import Transport
 
 
+class DummyNetwork:
+    def __init__(self) -> None:
+        self.nodes: Dict[str, Transport] = dict()
+
+    def add_transport(self, address: str, transport: Transport):
+        self.nodes[address] = transport
+
+    def get_transport(self, address: str) -> Transport:
+        return self.nodes[address]
+
+    def dispatch_message(self, data: str, target: str):
+        self.nodes[target].run_message_callbacks(data)
+
+
 class DummyTransport(Transport):
     """A simple dumb transport that implements required methods of Transport class."""
-    def __init__(self):
+    def __init__(self, dummy_network: DummyNetwork = None) -> None:
         super().__init__()
         self.is_running = gevent.event.Event()
-        self.received_messages = []
-        self.sent_messages = defaultdict(list)
+        self.received_messages: List[str] = []
+        self.sent_messages: Dict[str, List[str]] = defaultdict(list)
+        self.dummy_network = dummy_network
 
     def _run(self):
         self.is_running.wait()
@@ -23,4 +39,7 @@ class DummyTransport(Transport):
 
     def transmit_data(self, data: str, target_node: str = None):
         """Implements `transmit_data` method of the `Transport` class. """
-        self.sent_messages[target_node].append(data)
+        self.sent_messages[target_node].append(data)  # type: ignore
+
+        if target_node and self.dummy_network:
+            self.dummy_network.dispatch_message(data, target_node)

--- a/tests/test_dummy_network.py
+++ b/tests/test_dummy_network.py
@@ -1,0 +1,21 @@
+GENERATE_CLIENTS = 5
+
+
+def test_dummy_network(web3, generate_dummy_network):
+    network, clients = generate_dummy_network(GENERATE_CLIENTS)
+    assert network is not None
+    assert len(clients) == GENERATE_CLIENTS
+
+    messages_received = []
+
+    c1, c2 = clients[:2]
+    c1.open_channel(c2.address)
+
+    c2.transport.add_message_callback(lambda x: messages_received.append(x))
+
+    c1.transport.send_message(
+        c1.get_balance_proof(c2.address, transferred_amount=1),
+        c2.address
+    )
+
+    assert len(messages_received) == 1


### PR DESCRIPTION
@err508 I think this is what you have in mind to be able to dispatch messages between different clients.

The idea is from @pcppcp in RC.

No you just need to add all clients and the PFS to the `DummyNetwork` and then they can send messages to each other.