### PR TITLE
Update token fixture name

### DIFF
--- a/raiden_libs/messages/monitor_request.py
+++ b/raiden_libs/messages/monitor_request.py
@@ -48,18 +48,16 @@ class MonitorRequest(Message):
         """Return reward proof data serialized to binary"""
         return pack_data([
             'bytes32',
-            'uint192',
+            'uint256',
             'address',
             'uint256',
-            'uint256',
-            'address'
+            'uint256'
         ], [
             self.balance_proof.channel_identifier,
             self.reward_amount,
             self.balance_proof.token_network_address,
             self.balance_proof.chain_id,
             self.balance_proof.nonce,
-            self.monitor_address
         ])
 
     @classmethod

--- a/raiden_libs/test/fixtures/address.py
+++ b/raiden_libs/test/fixtures/address.py
@@ -73,7 +73,6 @@ def get_random_monitor_request(get_random_bp, get_random_address, get_random_pri
         monitor_request = MonitorRequest(
             balance_proof,
             non_closing_signature,
-            reward_sender_address=get_random_address(),
             reward_amount=random.randint(0, UINT192_MAX),
             monitor_address=get_random_address()
         )
@@ -99,7 +98,7 @@ def faucet_address(faucet_private_key):
 @pytest.fixture
 def send_funds(
     ethereum_tester,
-    standard_token_contract,
+    custom_token,
     faucet_address,
 ):
     """Send some tokens and eth to specified address."""
@@ -111,7 +110,7 @@ def send_funds(
             'gas': 21000,
             'value': 1 * denoms.ether
         })
-        standard_token_contract.functions.transfer(
+        custom_token.functions.transfer(
             target,
             10000
         ).transact({'from': faucet_address})

--- a/raiden_libs/test/fixtures/client.py
+++ b/raiden_libs/test/fixtures/client.py
@@ -14,8 +14,8 @@ def client_registry():
 
 @pytest.fixture
 def generate_raiden_client(
-        standard_token_network_contract,
-        standard_token_contract,
+        token_network,
+        custom_token,
         get_random_privkey,
         client_registry,
         send_funds,
@@ -26,7 +26,7 @@ def generate_raiden_client(
     def f():
         pk = get_random_privkey()
         ethereum_tester.add_account(pk)
-        c = MockRaidenNode(pk, standard_token_network_contract, standard_token_contract)
+        c = MockRaidenNode(pk, token_network, custom_token)
         c.client_registry = client_registry
         client_registry[c.address] = c
         send_funds(c.address)
@@ -35,7 +35,7 @@ def generate_raiden_client(
 
 
 @pytest.fixture
-def generate_raiden_clients(generate_raiden_client):
+def generate_raiden_clients(web3, generate_raiden_client):
     """Factory function to generate a list of raiden clients."""
     def f(count=1):
         return [generate_raiden_client() for x in range(count)]

--- a/tests/test_client_mock.py
+++ b/tests/test_client_mock.py
@@ -51,13 +51,13 @@ def test_message_signature(generate_raiden_clients):
     assert is_same_address(fee_info.signer, c1.address)
 
 
-def test_close_settle(generate_raiden_clients, wait_for_blocks, standard_token_contract):
+def test_close_settle(generate_raiden_clients, wait_for_blocks, custom_token):
     """Tests channel life cycle for mocked client"""
     c1, c2 = generate_raiden_clients(2)
     c1.open_channel(c2.address)
 
-    initial_balance_c1 = standard_token_contract.functions.balanceOf(c1.address).call()
-    initial_balance_c2 = standard_token_contract.functions.balanceOf(c2.address).call()
+    initial_balance_c1 = custom_token.functions.balanceOf(c1.address).call()
+    initial_balance_c2 = custom_token.functions.balanceOf(c2.address).call()
     transfer_c1 = 5
     transfer_c2 = 6
 
@@ -93,19 +93,19 @@ def test_close_settle(generate_raiden_clients, wait_for_blocks, standard_token_c
         (balance_proof_c2.locksroot, balance_proof.locksroot)
     )
 
-    final_balance_c1 = standard_token_contract.functions.balanceOf(c1.address).call()
-    final_balance_c2 = standard_token_contract.functions.balanceOf(c2.address).call()
+    final_balance_c1 = custom_token.functions.balanceOf(c1.address).call()
+    final_balance_c2 = custom_token.functions.balanceOf(c2.address).call()
     assert final_balance_c1 == initial_balance_c1 + (transfer_c1 - transfer_c2)
     assert final_balance_c2 == initial_balance_c2 - (transfer_c1 - transfer_c2)
 
 
-def test_client_one_side_settle(generate_raiden_clients, wait_for_blocks, standard_token_contract):
+def test_client_one_side_settle(generate_raiden_clients, wait_for_blocks, custom_token):
     """Tests channel settle without updateTransfer"""
     c1, c2 = generate_raiden_clients(2)
     c1.open_channel(c2.address)
 
-    initial_balance_c1 = standard_token_contract.functions.balanceOf(c1.address).call()
-    initial_balance_c2 = standard_token_contract.functions.balanceOf(c2.address).call()
+    initial_balance_c1 = custom_token.functions.balanceOf(c1.address).call()
+    initial_balance_c2 = custom_token.functions.balanceOf(c2.address).call()
     transfer_c1 = 5
 
     c1.deposit_to_channel(c2.address, 100)
@@ -130,7 +130,7 @@ def test_client_one_side_settle(generate_raiden_clients, wait_for_blocks, standa
         ('0x%064x' % 0, balance_proof.locksroot)
     )
 
-    final_balance_c1 = standard_token_contract.functions.balanceOf(c1.address).call()
-    final_balance_c2 = standard_token_contract.functions.balanceOf(c2.address).call()
+    final_balance_c1 = custom_token.functions.balanceOf(c1.address).call()
+    final_balance_c2 = custom_token.functions.balanceOf(c2.address).call()
     assert final_balance_c1 == initial_balance_c1 + (transfer_c1)
     assert final_balance_c2 == initial_balance_c2 - (transfer_c1)

--- a/tests/test_private_contract.py
+++ b/tests/test_private_contract.py
@@ -2,12 +2,12 @@ from raiden_libs.private_contract import PrivateContract
 
 
 def test_private_contract(
-    standard_token_contract,
+    custom_token,
     generate_raiden_clients,
     wait_for_transaction
 ):
     client1, client2 = generate_raiden_clients(2)
-    private_contract = PrivateContract(standard_token_contract)
+    private_contract = PrivateContract(custom_token)
     balance = private_contract.functions.balanceOf(client1.address).call()
     tx_hash = private_contract.functions.transfer(client2.address, balance).transact(
         private_key=client1.privkey


### PR DESCRIPTION
- replace `standard_token_contract` with `custom_token` (to use a single token for all tests)
- also updates MS reward proof serialization