### PR TITLE
Increased the default number of retries to 3

### DIFF
--- a/raiden_libs/network/matrix/client.py
+++ b/raiden_libs/network/matrix/client.py
@@ -9,7 +9,6 @@ from matrix_client.client import CACHE, MatrixClient
 from matrix_client.errors import MatrixRequestError
 from matrix_client.user import User
 from requests.adapters import HTTPAdapter
-from requests import Session
 
 from .room import Room
 
@@ -39,7 +38,6 @@ class GMatrixHttpApi(MatrixHttpApi):
             default_429_wait_ms=default_429_wait_ms,
         )
 
-        session = Session()
         http_adapter = HTTPAdapter(
             max_retries=max_retries,
             pool_maxsize=pool_maxsize,
@@ -48,13 +46,9 @@ class GMatrixHttpApi(MatrixHttpApi):
             max_retries=max_retries,
             pool_maxsize=pool_maxsize,
         )
-        session.mount('http://', http_adapter)
-        session.mount('https://', https_adapter)
-
-        lock = Semaphore(pool_maxsize)
-
-        self.session = session
-        self.lock = lock
+        self.session.mount('http://', http_adapter)
+        self.session.mount('https://', https_adapter)
+        self.lock = Semaphore(pool_maxsize)
 
     def _send(self, *args, **kwargs):
         with self.lock:

--- a/raiden_libs/network/matrix/client.py
+++ b/raiden_libs/network/matrix/client.py
@@ -24,19 +24,12 @@ class GMatrixHttpApi(MatrixHttpApi):
     """
     def __init__(
             self,
-            base_url,
-            token=None,
-            identity=None,
-            default_429_wait_ms=5000,
+            *args,
             max_retries=3,
             pool_maxsize=256,
+            **kwargs,
     ):
-        super().__init__(
-            base_url=base_url,
-            token=token,
-            identity=identity,
-            default_429_wait_ms=default_429_wait_ms,
-        )
+        super().__init__(*args, **kwargs)
 
         http_adapter = HTTPAdapter(
             max_retries=max_retries,


### PR DESCRIPTION
On some circunstances, e.g. the matrix server is being restarted, the
http request will fail and an exception will be raised. This will result
in the raiden client exiting, since atm it cannot recover from an
unvailable transport server.

This enables retries by default, allowing the requests to try a few
times before giving up and making the node exit.