### PR TITLE
Fix password for pbkdf2 private key

### DIFF
--- a/raiden_libs/utils/private_key.py
+++ b/raiden_libs/utils/private_key.py
@@ -55,6 +55,8 @@ def get_private_key(key_path, password_path=None):
                         password = password_file.readline().strip()
                 else:
                     password = getpass.getpass("Enter the private key password: ")
+                if json_data["crypto"]["kdf"] == "pbkdf2":
+                    password = password.encode()
                 private_key = encode_hex(decode_keyfile_json(json_data, password))
             except ValueError:
                 log.fatal("Invalid private key format or password!")


### PR DESCRIPTION
Issue: getting the private key from the private key json file fails for Parity generated files, with `pbkdf2`.

`hashlib.pbkdf2_hmac` used in the `eth-keyfile` package expects the `password` in `bytes`, as mentioned in their docs: https://docs.python.org/3/library/hashlib.html#key-derivation.

`Crypto.Protocol.KDF.scrypt` expects a `string`, https://pycryptodome.readthedocs.io/en/latest/src/protocol/kdf.html#Crypto.Protocol.KDF.scrypt, which is what Geth is using.

I think this should be handled in `eth-keyfile` https://github.com/ethereum/eth-keyfile/blob/8677c0906f4435da2e5c58104f6ba389460d11a3/eth_keyfile/keyfile.py#L85, but this PR is a temporary fix for us.


