### PR TITLE
Fix bad signature in get_monitor_request

### DIFF
--- a/raiden_libs/messages/monitor_request.py
+++ b/raiden_libs/messages/monitor_request.py
@@ -87,10 +87,14 @@ class MonitorRequest(Message):
         return to_checksum_address(signer)
 
     @property
-    def non_closing_signer(self) -> str:
+    def non_closing_data(self) -> bytes:
         serialized = self.balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
+        return serialized + decode_hex(self.balance_proof.signature)
+
+    @property
+    def non_closing_signer(self) -> str:
         signer = eth_recover(
-            data=serialized + decode_hex(self.balance_proof.signature),
+            data=self.non_closing_data,
             signature=decode_hex(self.non_closing_signature),
         )
         return to_checksum_address(signer)

--- a/raiden_libs/test/mocks/client.py
+++ b/raiden_libs/test/mocks/client.py
@@ -284,9 +284,8 @@ class MockRaidenNode:
                 monitor_request.serialize_reward_proof(),
             ),
         )
-        non_closing_data = balance_proof.serialize_bin() + decode_hex(balance_proof.signature)
         monitor_request.non_closing_signature = encode_hex(
-            eth_sign(self.privkey, non_closing_data),
+            eth_sign(self.privkey, monitor_request.non_closing_data),
         )
         return monitor_request
 


### PR DESCRIPTION
The way signatures are created and check in `mocks.client.get_monitor_request` and `messages.monitor_request.non_closing_signer` don't match. I assumed the latter is correct and made them consistent.

Since the bug was part of the tests, I didn't add a test for this problem.